### PR TITLE
Sp3.sc2.project structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ lib/
 erl_crash.dump
 *~
 .project
+.settings
 
 # Do not Ignore these
 !doc/overview.edoc

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ install: get_libs
 ### Command: make run
 ### Downloads all depenedencies, bulds entire project and runs the project.
 run: compile
-	erl -pa $(PWD)/ebin $(PWD)/lib/*/ebin -boot start_sasl -s reloader -s engine -sname database -setcookie database -mnesia dir '"/home/database/Mnesia.Database"' -s database init
+	erl -pa ebin/ lib/*/ebin/ -boot start_sasl -s reloader -s engine -sname database -setcookie database -mnesia dir '"/home/database/Mnesia.Database"' -s database init
 
 ### Command: make docs
 ### Genereats all of the documentation files

--- a/Makefile
+++ b/Makefile
@@ -14,13 +14,12 @@ APP := website
 ### The commands in this sections should not be used in general, but can be used
 ### if there is need for it
 ################################################################################
-compile: get_libs compile_src
-
-compile_src: get_libs
-	./rebar compile
+compile:
+	@./rebar compile skip_deps=true
 
 get_libs:
 	@./rebar get-deps
+	@./rebar compile
 
 clean_libs:
 	@./rebar delete-deps
@@ -47,13 +46,25 @@ clean_emacs_vsn_files:
 ### Downloads all dependencies and builds the entire project
 all: compile
 
+install: get_libs
+
+### Command: make run
+### Downloads all depenedencies, bulds entire project and runs the project.
+run: compile
+	erl -pa $(PWD)/ebin $(PWD)/lib/*/ebin -boot start_sasl -s reloader -s engine -sname database -setcookie database -mnesia dir '"/home/database/Mnesia.Database"' -s database init
+
+### Command: make docs
+### Genereats all of the documentation files
+docs:
+	@$(ERL) -noshell -run edoc_run application '$(APP)' '"."' '[{packages, false},{private, true}]'
+
 ### Command: make clean
 ### Cleans the directory of the following things:
 ### * Libraries, including 'lib' folder.
 ### * Emacs versioning files.
 ### * All erlang .beam files, including 'ebin' folder
 clean: clean_libs clean_emacs_vsn_files
-	./rebar clean
+	@./rebar clean
 	rm -f erl_crash.dump
 	rm -rf ebin/
 
@@ -63,12 +74,30 @@ clean: clean_libs clean_emacs_vsn_files
 clean_docs:
 	find doc/ -type f -not -name 'overview.edoc' | xargs rm
 
-### Command: make run
-### Downloads all depenedencies, bulds entire project and runs the project.
-run: compile
-	./start.sh
-
-### Command: make docs
-### Genereats all of the documentation files
-docs: compile_src
-	@$(ERL) -noshell -run edoc_run application '$(APP)' '"."' '[{packages, false},{private, true}]'
+### Command: make help
+### Prints an explanation of the commands in this Makefile
+help:
+	@echo "###################################################################"
+	@echo "Commands:"
+	@echo ""
+	@echo "'make'"
+	@echo "Compiles all the project sources. Does NOT compile libraries"
+	@echo ""
+	@echo "'make install'"
+	@echo "Downloads and compiles all libraries"
+	@echo ""
+	@echo "'make run'"
+	@echo "Compiles and runs the project. Does NOT compile libraries"
+	@echo ""
+	@echo "'make docs'"
+	@echo "Generates documentation for the project"
+	@echo ""
+	@echo "'make clean'"
+	@echo "Cleans all the project, including dependencies"
+	@echo ""
+	@echo "'make clean_docs'"
+	@echo "Cleans all of the documentation files, except for 'overview.edoc'"
+	@echo ""
+	@echo "'make help'"
+	@echo "Prints an explanation of the commands in this Makefile"
+	@echo "###################################################################"

--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,5 @@
 %%-*- mode: erlang -*-
 {deps_dir, ["lib"]}.
 {deps, [{webmachine, "1.10.*", {git, "git://github.com/basho/webmachine", "HEAD"}},
-		{erlastic_search, ".*", {git, "git://github.com/tsloughter/erlastic_search.git", {branch, "helllamer_changes"}}}
+	{erlastic_search, ".*", {git, "git://github.com/tsloughter/erlastic_search.git", {branch, "helllamer_changes"}}}
 ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,30 @@
 %%-*- mode: erlang -*-
+
+%% Require a certain version of Erlang
+{require_otp_vsn, "R16B01|R16B02"}.
+
+%% Specify library paths
+{lib_dirs, ["lib", "lib/webmachine/"]}.
+
+%% Edoc options
+%% Checks coverage of unit tests
+{cover_enabled, true}.
+{edoc_opts, [{preprocess, true}]}.
+{eunit_opts, [verbose]}.
+
+%% Erlang compiler options
+{erl_opts, [debug_info,
+	    verbose,
+
+	    %% This will not work at the moment because there is a problem with static_resources.erl.
+	    %%warnings_as_errors,
+
+	    %% This is needed because there are files in src/ that includes a file from here
+	    %% If header files from other libraries needs to be included, then the path to that include
+	    %% included below (as a separate {i, Dir} entry)
+	    {i, "lib/webmachine/include/"}
+	   ]}.
+
 {deps_dir, ["lib"]}.
 {deps, [{webmachine, "1.10.*", {git, "git://github.com/basho/webmachine", "HEAD"}},
 	{erlastic_search, ".*", {git, "git://github.com/tsloughter/erlastic_search.git", {branch, "helllamer_changes"}}}

--- a/src/database.erl
+++ b/src/database.erl
@@ -11,10 +11,10 @@
 -module(database).
 -compile(export_all).
 -include_lib("stdlib/include/qlc.hrl").
--include("include/user.hrl").
--include("include/unique_ids.hrl").
--include("include/resource.hrl").
--include("include/stream.hrl").
+-include("user.hrl").
+-include("unique_ids.hrl").
+-include("resource.hrl").
+-include("stream.hrl").
 
 %% @doc
 %% Function: init/0 

--- a/src/db_api.erl
+++ b/src/db_api.erl
@@ -14,10 +14,10 @@
 
 -module(db_api).
 -include_lib("stdlib/include/qlc.hrl").
--include("include/user.hrl").
--include("include/resource.hrl").
--include("include/stream.hrl").
--include("include/unique_ids.hrl").
+-include("user.hrl").
+-include("resource.hrl").
+-include("stream.hrl").
+-include("unique_ids.hrl").
 %% ====================================================================
 %% API functions
 %% ====================================================================

--- a/src/rd_api.erl
+++ b/src/rd_api.erl
@@ -10,7 +10,7 @@
 %% @end
 -module(rd_api).
 -include_lib("stdlib/include/qlc.hrl").
--include("include/resource.hrl").
+-include("resource.hrl").
 
 %% ====================================================================
 %% API functions

--- a/src/static_resource.erl
+++ b/src/static_resource.erl
@@ -19,8 +19,9 @@
 
 -record(context, {root,response_body=undefined,metadata=[]}).
 
+-include("webmachine.hrl").
 -include_lib("kernel/include/file.hrl").
--include_lib("webmachine/include/webmachine.hrl").
+
 
 init(ConfigProps) ->
     {root, Root} = proplists:lookup(root, ConfigProps),

--- a/src/streams_resource.erl
+++ b/src/streams_resource.erl
@@ -17,8 +17,8 @@
 	 put_resource/2,
 	 post_is_create/2]).
 
--include_lib("webmachine/include/webmachine.hrl").
--include("include/stream.hrl").
+-include("webmachine.hrl").
+-include("stream.hrl").
 
 %% @doc
 %% Function: init/1

--- a/src/users_resource.erl
+++ b/src/users_resource.erl
@@ -15,7 +15,7 @@
 	 json_handler/2,
 	 json_get/2]).
 
--include_lib("webmachine/include/webmachine.hrl").
+-include("webmachine.hrl").
 
 init([]) -> {ok, undefined}.
 

--- a/start.sh
+++ b/start.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-cd `dirname $0`
-exec erl -pa $PWD/ebin $PWD/lib/*/ebin -boot start_sasl -s reloader -s engine -sname database -setcookie database -mnesia dir '"/home/database/Mnesia.Database"' -s database init


### PR DESCRIPTION
Eclipse notes:
To work better in eclipse:
1. Add Erlang nature to the eclipse project. Right click on project -> Configure -> Add Erlang nature
1. Add Erlang build paths under Project -> Properties -> Erlang
   2a. Source dir should be: 
   src

2.b Include dir should be: 
include
lib/webmachine/include
1. External tool command should be set to: 
   -e "make run"
