### PR TITLE
Small change in add_fields to handle valid JSON objects

### DIFF
--- a/src/streams.erl
+++ b/src/streams.erl
@@ -396,7 +396,7 @@ create_update(Stream) ->
 -spec add_field(Stream::string(),FieldName::string(),FieldValue::string()) -> string().
 
 add_field(Stream,FieldName,FieldValue) ->
-	string:substr(Stream,1,length(Stream)-2) ++ ",\n" ++ FieldName ++ " : " ++ FieldValue ++ "\n}".
+	string:substr(Stream,1,length(Stream)-1) ++ ",\n\"" ++ FieldName ++ "\" : " ++ FieldValue ++ "\n}".
 	
 
 %% @doc


### PR DESCRIPTION
Changed add_field to correctly handle JSON objects that were not formatted with a line break after each key-value line and to make sure that the new fields added where stored as "FieldName" instead of just FieldName.
