### PR TITLE
Sp6.sc3.api consistency

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -38,7 +38,7 @@
 {deps_dir, ["lib"]}.
 {deps, [
 	{webmachine, "1.10.*", {git, "git://github.com/basho/webmachine", "HEAD"}},
-	{erlastic_search, ".*", {git, "git://github.com/projectcs13/erlastic_search.git", {branch, "helllamer_changes"}}},
+	{erlastic_search, ".*", {git, "git://github.com/projectcs13/erlastic_search.git", {branch, "master"}}},
 	{elasticsearch,	".*", {git, "git://github.com/projectcs13/elasticsearch.git", {branch, "configured"}}, [raw]},
 	{"rabbitmq-server", ".*", {git, "git://github.com/rabbitmq/rabbitmq-server.git", {tag, "rabbitmq_v3_1_5"}}, [raw]},
 	{"rabbitmq-codegen", ".*", {git, "git://github.com/rabbitmq/rabbitmq-codegen.git", {tag, "rabbitmq_v3_1_5"}}, [raw]},

--- a/src/api_help.erl
+++ b/src/api_help.erl
@@ -340,3 +340,18 @@ convert_binary_to_string([First|Rest]) ->
 					 false -> [First] ++ convert_binary_to_string(Rest)
 				 end
 	end.
+
+%% @doc
+%% Purpose: generate an appropriate error string depending on the error code
+%%
+%% TODO: parse Body for more accurate response text
+%%
+-spec generate_error(JSONString::string(), integer()) -> string().
+
+generate_error(Body, ErrorCode) ->
+	ErrorString = integer_to_list(ErrorCode),
+	case ErrorCode of
+		404 -> Reason = "not found";
+		_ -> Reason = binary_to_list(Body)
+	end,
+	"Status " ++ ErrorString ++ "\nError: " ++ Reason.

--- a/src/datapoints.erl
+++ b/src/datapoints.erl
@@ -66,28 +66,30 @@ content_types_provided(ReqData, State) ->
 -spec process_post(ReqData::tuple(), State::string()) -> {true, tuple(), string()}.
 process_post(ReqData, State) ->
 	case api_help:is_search(ReqData) of
-			false ->
-				{DatapointJson,_,_} = api_help:json_handler(ReqData, State),
-				Id = id_from_path(ReqData),
-				case Id of
-					undefined -> {{halt, 404}, ReqData, State};
-					_ ->
-						case lib_json:get_field(DatapointJson,"timestamp") of
-							undefined ->
-								{{Year,Month,Day},{Hour,Minute,Second}} = calendar:local_time(),
-								TimeStamp = generate_timestamp([Year,Month,Day,Hour,Minute,Second],0) ++ ".000",
-								TimeStampAdded = api_help:add_field(DatapointJson, "timestamp", TimeStamp);
-							_ ->
-								TimeStampAdded = DatapointJson
-						end,
-						FinalJson = api_help:add_field(TimeStampAdded, "streamid", Id),
-						case erlastic_search:index_doc(?INDEX, "datapoint", FinalJson) of
-							{error, Reason} -> {{error,Reason}, wrq:set_resp_body("{\"error\":\""++ atom_to_list(Reason) ++ "\"}", ReqData), State};
-							{ok,List} -> {true, wrq:set_resp_body(lib_json:encode(List), ReqData), State}
-						end
-				end;
-			true ->
-				process_search(ReqData,State, post)	
+		false ->
+			{DatapointJson,_,_} = api_help:json_handler(ReqData, State),
+			Id = id_from_path(ReqData),
+			case Id of
+				undefined -> {{halt, 404}, ReqData, State};
+				_ ->
+					case lib_json:get_field(DatapointJson,"timestamp") of
+						undefined ->
+							{{Year,Month,Day},{Hour,Minute,Second}} = calendar:local_time(),
+							TimeStamp = generate_timestamp([Year,Month,Day,Hour,Minute,Second],0) ++ ".000",
+							TimeStampAdded = api_help:add_field(DatapointJson, "timestamp", TimeStamp);
+						_ ->
+							TimeStampAdded = DatapointJson
+					end,
+					FinalJson = api_help:add_field(TimeStampAdded, "streamid", Id),
+					case erlastic_search:index_doc(?INDEX, "datapoint", FinalJson) of
+						{error, {Code, Body}} -> 
+            				ErrorString = api_help:generate_error(Body, Code),
+            				{{halt, Code}, wrq:set_resp_body(ErrorString, ReqData), State};
+						{ok,List} -> {true, wrq:set_resp_body(lib_json:encode(List), ReqData), State}
+					end
+			end;
+		true ->
+			process_search(ReqData,State, post)	
 	end.
 
 
@@ -98,28 +100,30 @@ process_post(ReqData, State) ->
 %% @end
 -spec get_datapoint(ReqData::tuple(), State::string()) -> {list(), tuple(), string()}.
 get_datapoint(ReqData, State) ->
-        case wrq:get_qs_value("size",ReqData) of 
-            undefined ->
-                Size = 100;
-            SizeParam ->
-                Size = list_to_integer(SizeParam)
-        end,
-		case api_help:is_search(ReqData) of
-			false ->
-				Id = id_from_path(ReqData),			
-				case erlastic_search:search_limit(?INDEX, "datapoint", "streamid:" ++ Id, Size) of
-					{ok, Result} ->
-						EncodedResult = lib_json:encode(Result),
-						case re:run(EncodedResult, "\"max_score\":null", [{capture, first, list}]) of
-							{match, _} -> {{halt, 404}, ReqData, State};
-							nomatch -> FinalJson = lib_json:get_list_and_add_id(Result),
-						       {FinalJson, ReqData, State}
-						end;
-					_ -> {{halt, 404}, ReqData, State}
-				end; 
-			true ->
-				process_search(ReqData,State, get)	
-		end.
+    case wrq:get_qs_value("size",ReqData) of 
+        undefined ->
+            Size = 100;
+        SizeParam ->
+            Size = list_to_integer(SizeParam)
+    end,
+	case api_help:is_search(ReqData) of
+		false ->
+			Id = id_from_path(ReqData),			
+			case erlastic_search:search_limit(?INDEX, "datapoint", "streamid:" ++ Id, Size) of
+				{ok, Result} ->
+					EncodedResult = lib_json:encode(Result),
+					case re:run(EncodedResult, "\"max_score\":null", [{capture, first, list}]) of
+						{match, _} -> {{halt, 404}, ReqData, State};
+						nomatch -> FinalJson = lib_json:get_list_and_add_id(Result, data),
+					       {FinalJson, ReqData, State}
+					end;
+				{error, {Code, Body}} -> 
+        				ErrorString = api_help:generate_error(Body, Code),
+        				{{halt, Code}, wrq:set_resp_body(ErrorString, ReqData), State}
+			end; 
+		true ->
+			process_search(ReqData,State, get)	
+	end.
 
 
 %% @doc
@@ -144,39 +148,45 @@ get_datapoint(ReqData, State) ->
 -spec process_search(ReqData::tuple(), State::string(), term()) ->
 		{list(), tuple(), string()}.
 process_search(ReqData, State, post) ->
-		{Json,_,_} = api_help:json_handler(ReqData,State),
-		case erlastic_search:search_json(#erls_params{},?INDEX, "datapoint", Json) of
-				{error, Reason} -> {{error,Reason}, wrq:set_resp_body("{\"error\":\""++ atom_to_list(Reason) ++ "\"}", ReqData), State};
-				{ok,JsonStruct} ->
-						       FinalJson = lib_json:get_list_and_add_id(JsonStruct),
-						       {true,wrq:set_resp_body(lib_json:encode(FinalJson),ReqData),State}
-		end;
+	{Json,_,_} = api_help:json_handler(ReqData,State),
+	case erlastic_search:search_json(#erls_params{},?INDEX, "datapoint", Json) of
+			{error, {Code, Body}} -> 
+				ErrorString = api_help:generate_error(Body, Code),
+				{{halt, Code}, wrq:set_resp_body(ErrorString, ReqData), State};
+			{ok,JsonStruct} ->
+					       FinalJson = lib_json:get_list_and_add_id(JsonStruct),
+					       {true,wrq:set_resp_body(lib_json:encode(FinalJson),ReqData),State}
+	end;
 process_search(ReqData, State, get) ->
-		TempQuery = wrq:req_qs(ReqData),
-		Id = id_from_path(ReqData),
-        case wrq:get_qs_value("size",ReqData) of 
-		    undefined ->
-		        Size = 100;
-		    SizeParam ->
-		        Size = list_to_integer(SizeParam)
-        end,
-		case TempQuery of
-			[] ->   
-				case erlastic_search:search_limit(?INDEX, "datapoint","streamid:" ++ Id ++ "&sort=timestamp:asc", Size) of
-					{error,Reason} -> {{error,Reason}, wrq:set_resp_body("{\"error\":\""++ atom_to_list(Reason) ++ "\"}", ReqData), State};
-                	{ok,JsonStruct} ->
-						       FinalJson = lib_json:get_list_and_add_id(JsonStruct),
-						       {FinalJson, ReqData, State}
-			 	end;
-			_ ->
-				TransformedQuery="streamid:" ++ Id ++ transform(TempQuery) ++ "&sort=timestamp:asc",
-				case erlastic_search:search_limit(?INDEX, "datapoint",TransformedQuery, Size) of
-					{error,Reason} -> {{error,Reason}, wrq:set_resp_body("{\"error\":\""++ atom_to_list(Reason) ++ "\"}", ReqData), State};
-                	{ok,JsonStruct} ->
-						       FinalJson = lib_json:get_list_and_add_id(JsonStruct),
-						       {FinalJson, ReqData, State}
-				end
-		end.
+	TempQuery = wrq:req_qs(ReqData),
+	Id = id_from_path(ReqData),
+    case wrq:get_qs_value("size",ReqData) of 
+	    undefined ->
+	        Size = 100;
+	    SizeParam ->
+	        Size = list_to_integer(SizeParam)
+    end,
+	case TempQuery of
+		[] ->   
+			case erlastic_search:search_limit(?INDEX, "datapoint","streamid:" ++ Id ++ "&sort=timestamp:asc", Size) of
+				{error, {Code, Body}} -> 
+    				ErrorString = api_help:generate_error(Body, Code),
+    				{{halt, Code}, wrq:set_resp_body(ErrorString, ReqData), State};
+            	{ok,JsonStruct} ->
+			       FinalJson = lib_json:get_list_and_add_id(JsonStruct, data),
+			       {FinalJson, ReqData, State}
+		 	end;
+		_ ->
+			TransformedQuery="streamid:" ++ Id ++ transform(TempQuery) ++ "&sort=timestamp:asc",
+			case erlastic_search:search_limit(?INDEX, "datapoint",TransformedQuery, Size) of
+				{error, {Code, Body}} -> 
+    				ErrorString = api_help:generate_error(Body, Code),
+    				{{halt, Code}, wrq:set_resp_body(ErrorString, ReqData), State};
+            	{ok,JsonStruct} ->
+			       FinalJson = lib_json:get_list_and_add_id(JsonStruct, data),
+			       {FinalJson, ReqData, State}
+			end
+	end.
 
 
 %% @doc

--- a/src/lib_json.erl
+++ b/src/lib_json.erl
@@ -30,7 +30,8 @@
 %% Specialized functions - Exports
 %% ====================================================================
 -export([get_and_add_id/1, 
-	 get_list_and_add_id/1
+	 get_list_and_add_id/1,
+     get_list_and_add_id/2
 	]).
 
 %% ====================================================================
@@ -391,6 +392,7 @@ get_and_add_id(JsonStruct) ->
 %% @doc 
 %% Get the search results and performs get_and_add_id/1 on each
 %% elements in the result list.
+%% NOTE: Deprecated, use get_list_and_add_id/2 instead
 %%
 %% TODO Move to api_help
 %% @end 
@@ -399,6 +401,21 @@ get_list_and_add_id(JsonStruct) ->
     HitsList = get_field(JsonStruct, "hits.hits"),
     AddedId = lists:map(fun(X) -> get_and_add_id(X) end, HitsList),
     set_attr(hits, AddedId).
+
+%% @doc 
+%% Get the search results and performs get_and_add_id/1 on each
+%% elements in the result list. The resulting list will be returned
+%% as a proper JSON object with the JsonKey as the attribute.
+%%
+%% Return: get_list_and_add_id(List, Attribute) -> "{\"Attribute\": List}"
+%%
+%% TODO Move to api_help
+%% @end 
+-spec get_list_and_add_id(JsonStruct::mochijson(), atom()) -> json_string().
+get_list_and_add_id(JsonStruct, JsonKey) ->
+    HitsList = get_field(JsonStruct, "hits.hits"),
+    AddedId = lists:map(fun(X) -> get_and_add_id(X) end, HitsList),
+    set_attr(JsonKey, AddedId).
 
 
 %% ====================================================================

--- a/src/resources.erl
+++ b/src/resources.erl
@@ -78,14 +78,18 @@ content_types_accepted(ReqData, State) ->
 -spec delete_resource(ReqData::tuple(), State::string()) -> {string(), tuple(), string()}.
 delete_resource(ReqData, State) ->
 	Id = proplists:get_value('resourceid', wrq:path_info(ReqData)),
-	erlang:display("DELETE request - check permission here"),
 	%% TODO Authentication
 	case delete_streams_with_resource_id(Id) of
-		{error,Reason} -> {{error,Reason}, wrq:set_resp_body("{\"error\":\""++ atom_to_list(Reason) ++ "\"}", ReqData), State};
+		{error, {Code, Body}} -> 
+            ErrorString = api_help:generate_error(Body, Code),
+            {{halt, Code}, wrq:set_resp_body(ErrorString, ReqData), State};
 		{ok} ->
 			case erlastic_search:delete_doc(?INDEX,"resource", Id) of
-				{error,Reason} -> {{error,Reason}, wrq:set_resp_body("{\"error\":\""++ atom_to_list(Reason) ++ "\"}", ReqData), State};
-				{ok,List} -> {true,wrq:set_resp_body(lib_json:encode(List),ReqData),State}
+				{error, {Code, Body}} -> 
+            		ErrorString = api_help:generate_error(Body, Code),
+            		{{halt, Code}, wrq:set_resp_body(ErrorString, ReqData), State};
+				{ok,List} -> 
+					{true,wrq:set_resp_body(lib_json:encode(List),ReqData),State}
 			end
 	end.
 
@@ -125,10 +129,8 @@ get_streams(JSON) when is_tuple(JSON)->
 	get_streams(Result);
 get_streams(undefined) ->
 	[];
-
 get_streams([]) ->
 	[];
-
 get_streams([JSON | Tl]) ->
 	case lib_json:get_field(JSON, "_id") of
 		undefined -> [];
@@ -167,7 +169,9 @@ process_post(ReqData, State) ->
 			Date = generate_date([Year,Month,Day]),
 			DateAdded = api_help:add_field(Resource,"creation_date",Date),
 			case erlastic_search:index_doc(?INDEX,"resource",DateAdded) of 
-				{error, Reason} -> {{error,Reason}, wrq:set_resp_body("{\"error\":\""++ atom_to_list(Reason) ++ "\"}", ReqData), State};
+				{error, {Code, Body}} -> 
+            		ErrorString = api_help:generate_error(Body, Code),
+            		{{halt, Code}, wrq:set_resp_body(ErrorString, ReqData), State};
 				{ok, Json} -> 
 					ResourceId = lib_json:get_field(Json, "_id"),
 					suggest:add_suggestion(Resource, ResourceId),
@@ -192,7 +196,7 @@ process_search_post(ReqData, State) ->
 		undefined ->
 			{{halt,405}, ReqData, State};
 		UserId ->
-			    case wrq:get_qs_value("size",ReqData) of 
+			case wrq:get_qs_value("size",ReqData) of 
 	            undefined ->
 	                Size = "10";
 	            SizeParam ->
@@ -207,8 +211,9 @@ process_search_post(ReqData, State) ->
 			UserQuery = "\"user_id\":" ++ UserId,
 			FilteredJson = filter_json(Json, UserQuery, From, Size),
 			case erlastic_search:search_json(#erls_params{},?INDEX, "resource", FilteredJson) of % Maybe wanna take more
-				{error,Reason} -> 
-					{{error,Reason}, wrq:set_resp_body("{\"error\":\""++ atom_to_list(Reason) ++ "\"}", ReqData), State};
+				{error, {Code, Body}} -> 
+            		ErrorString = api_help:generate_error(Body, Code),
+            		{{halt, Code}, wrq:set_resp_body(ErrorString, ReqData), State};
 				{ok,List} -> {true,wrq:set_resp_body(lib_json:encode(List),ReqData),State} % May need to convert
 			end
 	end.
@@ -225,14 +230,16 @@ put_resource(ReqData, State) ->
 	%check if doc already exists
 	Id = id_from_path(ReqData),
 	case erlastic_search:get_doc(?INDEX, "resource", Id) of
-		{error, Reason} -> 
-			{{error,Reason}, wrq:set_resp_body("{\"error\":\""++ atom_to_list(Reason) ++ "\"}", ReqData), State};
+		{error, {Code, Body}} -> 
+            ErrorString = api_help:generate_error(Body, Code),
+            {{halt, Code}, wrq:set_resp_body(ErrorString, ReqData), State};
 		{ok, _} ->
 			{UserJson,_,_} = api_help:json_handler(ReqData, State),
 			Update = api_help:create_update(UserJson),
 			case api_help:update_doc(?INDEX,"resource", Id, Update) of 
-				{error, Reason} -> 
-					{{error,Reason}, wrq:set_resp_body("{\"error\":\""++ atom_to_list(Reason) ++ "\"}", ReqData), State};
+				{error, {Code, Body}} -> 
+            		ErrorString = api_help:generate_error(Body, Code),
+            		{{halt, Code}, wrq:set_resp_body(ErrorString, ReqData), State};
 				{ok,List} -> 
 					suggest:update_resource(UserJson, Id),
 					{true,wrq:set_resp_body(lib_json:encode(List),ReqData),State}
@@ -265,17 +272,19 @@ get_resource(ReqData, State) ->
 							Query = "user_id:" ++ UserId
 					end,
 					case erlastic_search:search_limit(?INDEX, "resource", Query, Size) of % Maybe wanna take more
-						{error,Reason} -> 
-							{{error,Reason}, wrq:set_resp_body("{\"error\":\""++ atom_to_list(Reason) ++ "\"}", ReqData), State};
+						{error, {Code, Body}} -> 
+            				ErrorString = api_help:generate_error(Body, Code),
+            				{{halt, Code}, wrq:set_resp_body(ErrorString, ReqData), State};
 						{ok,JsonStruct} ->
-							FinalJson = lib_json:get_list_and_add_id(JsonStruct),
+							FinalJson = lib_json:get_list_and_add_id(JsonStruct, resources),
 							{FinalJson, ReqData, State} 
 					end;
 				ResourceId ->
 					% Get specific resource
 					case erlastic_search:get_doc(?INDEX, "resource", ResourceId) of 
-						{error,Reason} -> 
-							{{error,Reason}, wrq:set_resp_body("{\"error\":\""++ atom_to_list(Reason) ++ "\"}", ReqData), State};			
+						{error, {Code, Body}} -> 
+            				ErrorString = api_help:generate_error(Body, Code),
+            				{{halt, Code}, wrq:set_resp_body(ErrorString, ReqData), State};			
 						{ok,JsonStruct} ->
 							FinalJson = lib_json:get_and_add_id(JsonStruct),
 							{FinalJson, ReqData, State} 
@@ -298,15 +307,18 @@ process_search(ReqData, State, post) ->
 	{struct, JsonData} = mochijson2:decode(Json),
 	Query = api_help:transform(JsonData),
 	case erlastic_search:search_limit(?INDEX, "resource", Query, 10) of
-
-		{error,Reason} -> {{error,Reason}, wrq:set_resp_body("{\"error\":\""++ atom_to_list(Reason) ++ "\"}", ReqData), State};
+		{error, {Code, Body}} -> 
+            ErrorString = api_help:generate_error(Body, Code),
+            {{halt, Code}, wrq:set_resp_body(ErrorString, ReqData), State};
 		{ok,List} -> {true, wrq:set_resp_body(lib_json:encode(List),ReqData),State}
 	end;
 process_search(ReqData, State, get) ->
 	TempQuery = wrq:req_qs(ReqData),
 	TransformedQuery = api_help:transform(TempQuery),
 	case erlastic_search:search_limit(?INDEX, "resource", TransformedQuery, 10) of
-		{error,Reason} -> {{error,Reason}, wrq:set_resp_body("{\"error\":\""++ atom_to_list(Reason) ++ "\"}", ReqData), State};
+		{error, {Code, Body}} -> 
+            ErrorString = api_help:generate_error(Body, Code),
+            {{halt, Code}, wrq:set_resp_body(ErrorString, ReqData), State};
 		{ok,List} -> {lib_json:encode(List),ReqData,State} % May need to convert
 	end.
 

--- a/src/search.erl
+++ b/src/search.erl
@@ -105,16 +105,14 @@ process_search_post(ReqData, State) ->
         {Json,_,_} = api_help:json_handler(ReqData,State),
         FilteredJson = filter_json(Json, From, Size),
         case erlastic_search:search_json(#erls_params{},?INDEX, "stream", FilteredJson) of % Maybe wanna take more
-                {error,Reason1} ->
-                        StreamSearch = "\"error\"",
-                        {{halt,Reason1}, ReqData, State};
+                {error,{Code1, _Body}} ->
+                        {{halt, Code1}, ReqData, State};
                 {ok,List1} ->
                         StreamSearch = lib_json:encode(List1) % May need to convert
         end,
         case erlastic_search:search_json(#erls_params{},?INDEX, "user", FilteredJson) of % Maybe wanna take more
-                {error,Reason2} ->
-                        UserSearch = "\"error\"",
-                        {{halt,Reason2}, ReqData, State};
+                {error,{Code2, _Body}} ->
+                        {{halt, Code2}, ReqData, State};
                 {ok,List2} -> UserSearch = lib_json:encode(List2) % May need to convert
          end,
         SearchResults = "{\"streams\":"++ StreamSearch ++", \"users\":"++ UserSearch ++"}",

--- a/src/search.erl
+++ b/src/search.erl
@@ -105,13 +105,15 @@ process_search_post(ReqData, State) ->
         {Json,_,_} = api_help:json_handler(ReqData,State),
         FilteredJson = filter_json(Json, From, Size),
         case erlastic_search:search_json(#erls_params{},?INDEX, "stream", FilteredJson) of % Maybe wanna take more
-                {error,{Code1, _Body}} ->
+                {error,{Code1, _}} ->
+                        StreamSearch = [],
                         {{halt, Code1}, ReqData, State};
                 {ok,List1} ->
                         StreamSearch = lib_json:encode(List1) % May need to convert
         end,
         case erlastic_search:search_json(#erls_params{},?INDEX, "user", FilteredJson) of % Maybe wanna take more
-                {error,{Code2, _Body}} ->
+                {error,{Code2, _}} ->
+                        UserSearch = [],
                         {{halt, Code2}, ReqData, State};
                 {ok,List2} -> UserSearch = lib_json:encode(List2) % May need to convert
          end,

--- a/src/streams.erl
+++ b/src/streams.erl
@@ -57,7 +57,7 @@ allowed_methods(ReqData, State) ->
 			{['GET', 'PUT', 'DELETE'], ReqData, State};
 		[error] ->
 		    {[], ReqData, State} 
-end.
+	end.
 
 
 
@@ -91,16 +91,19 @@ content_types_accepted(ReqData, State) ->
 %% Purpose: Used to handle DELETE requests by deleting the stream in elastic search
 %% Returns: {Success, ReqData, State}, where Success is true if delete is successful
 %% and false otherwise.
+%% FIX: This function relies on direct contact with elastic search at localhost:9200
 %% @end
 -spec delete_resource(ReqData::term(),State::term()) -> {boolean(), term(), term()}.
 
 delete_resource(ReqData, State) ->
 	Id = proplists:get_value('stream', wrq:path_info(ReqData)),
 	case erlastic_search:delete_doc(?INDEX,"stream", Id) of
-			{error,Reason} -> {{error,Reason}, wrq:set_resp_body("{\"error\":\""++ atom_to_list(Reason) ++ "\"}", ReqData), State};
-			{ok,List} -> httpc:request(delete, {"http://localhost:9200/sensorcloud/datapoint/_query?q=streamid:" 
-                  		 ++ Id, []}, [], []),
-				 	{true,wrq:set_resp_body(lib_json:encode(List),ReqData),State}
+		{error, {Code, Body}} -> 
+			ErrorString = api_help:generate_error(Body, Code),
+			{{halt, Code}, wrq:set_resp_body(ErrorString, ReqData), State};
+		{ok,List} -> 
+			httpc:request(delete, {"http://localhost:9200/sensorcloud/datapoint/_query?q=streamid:" ++ Id, []}, [], []),
+			 	{true,wrq:set_resp_body(lib_json:encode(List),ReqData),State}
 	end.
 
 
@@ -135,7 +138,9 @@ process_post(ReqData, State) ->
 					Date = generate_date([Year,Month,Day]),
 					DateAdded = api_help:add_field(ResAdded,"creation_date",Date),
 					case erlastic_search:index_doc(?INDEX, "stream", DateAdded) of	
-						{error, Reason} -> {{error,Reason}, wrq:set_resp_body("{\"error\":\""++ atom_to_list(Reason) ++ "\"}", ReqData), State};
+						{error, {Code, Body}} -> 
+            				ErrorString = api_help:generate_error(Body, Code),
+            				{{halt, Code}, wrq:set_resp_body(ErrorString, ReqData), State};
 						{ok,List} -> 
 							suggest:update_suggestion(ResAdded),
 							{true, wrq:set_resp_body(lib_json:encode(List), ReqData), State}
@@ -155,8 +160,6 @@ process_post(ReqData, State) ->
 -spec process_search_post(ReqData::term(),State::term()) -> {boolean(), term(), term()}.
 
 process_search_post(ReqData, State) ->
-
-        erlang:display("search with json request"),
         case wrq:get_qs_value("size",ReqData) of 
             undefined ->
                 Size = "10";
@@ -177,9 +180,10 @@ process_search_post(ReqData, State) ->
                         ResQuery = "\"resource\":" ++ ResId,
                         FilteredJson = filter_json(Json, ResQuery, From, Size)
         end,
-        erlang:display(FilteredJson),
         case erlastic_search:search_json(#erls_params{},?INDEX, "stream", FilteredJson) of % Maybe wanna take more
-                {error,Reason} -> {{error,Reason}, wrq:set_resp_body("{\"error\":\""++ atom_to_list(Reason) ++ "\"}", ReqData), State};
+                {error, {Code, Body}} -> 
+            				ErrorString = api_help:generate_error(Body, Code),
+            				{{halt, Code}, wrq:set_resp_body(ErrorString, ReqData), State};
                 {ok,List} -> {true,wrq:set_resp_body(lib_json:encode(List),ReqData),State} % May need to convert
         end.
 
@@ -225,7 +229,9 @@ process_search_get(ReqData, State) ->
 	end,
 	FullQuery = lists:append(api_help:transform(URIQuery,ResDef or UserDef),Query),
 	case erlastic_search:search_limit(?INDEX, "stream", FullQuery,Size) of % Maybe wanna take more
-		{error,Reason} -> {{error,Reason}, wrq:set_resp_body("{\"error\":\""++ atom_to_list(Reason) ++ "\"}", ReqData), State};
+		{error, {Code, Body}} -> 
+            				ErrorString = api_help:generate_error(Body, Code),
+            				{{halt, Code}, wrq:set_resp_body(ErrorString, ReqData), State};
 		{ok,List} -> {lib_json:encode(List),ReqData,State} 
 	end.
 
@@ -243,7 +249,9 @@ put_stream(ReqData, State) ->
 	{Stream,_,_} = api_help:json_handler(ReqData,State),
 	Update = api_help:create_update(Stream),
 	case api_help:update_doc(?INDEX, "stream", StreamId, Update) of 
-		{error,Reason} -> {{error,Reason}, wrq:set_resp_body("{\"error\":\""++ atom_to_list(Reason) ++ "\"}", ReqData), State};
+		{error, {Code, Body}} -> 
+            				ErrorString = api_help:generate_error(Body, Code),
+            				{{halt, Code}, wrq:set_resp_body(ErrorString, ReqData), State};
 		{ok,List} -> {true,wrq:set_resp_body(lib_json:encode(List),ReqData),State}
 	end.
 
@@ -298,17 +306,19 @@ get_stream(ReqData, State) ->
 								 end
 					end,
 					case erlastic_search:search_limit(?INDEX, "stream", Query,Size) of % Maybe wanna take more
-						{error,Reason} -> 
-						      {{error,Reason}, wrq:set_resp_body("{\"error\":\""++ atom_to_list(Reason) ++ "\"}", ReqData), State};
-					        {ok,JsonStruct} ->
-						       FinalJson = lib_json:get_list_and_add_id(JsonStruct),
-						       {FinalJson, ReqData, State} 
+						{error, {Code, Body}} -> 
+            				ErrorString = api_help:generate_error(Body, Code),
+            				{{halt, Code}, wrq:set_resp_body(ErrorString, ReqData), State};
+					    {ok,JsonStruct} ->
+						    FinalJson = lib_json:get_list_and_add_id(JsonStruct, streams),
+						    {FinalJson, ReqData, State} 
 					end;
 				StreamId ->
 				% Get specific stream
 					case erlastic_search:get_doc(?INDEX, "stream", StreamId) of 
-						{error, Reason} -> 
-							{{error,Reason}, wrq:set_resp_body("{\"error\":\""++ atom_to_list(Reason) ++ "\"}", ReqData), State};
+						{error, {Code, Body}} -> 
+            				ErrorString = api_help:generate_error(Body, Code),
+            				{{halt, Code}, wrq:set_resp_body(ErrorString, ReqData), State};
 						{ok,JsonStruct} -> 	 
 						        FinalJson = lib_json:get_and_add_id(JsonStruct),
 						        {FinalJson, ReqData, State}

--- a/src/suggest.erl
+++ b/src/suggest.erl
@@ -86,7 +86,9 @@ get_suggestion(ReqData, State) ->
 					}                                      
 				}",
 			case erlastic_search:suggest(?INDEX, Query) of	
-				{error, Reason} -> {lib_json:encode(Reason),ReqData, State};
+				{error, {Code, Body}} -> 
+    				ErrorString = api_help:generate_error(Body, Code),
+    				{{halt, Code}, wrq:set_resp_body(ErrorString, ReqData), State};
 				{ok,List} -> 
 					EncodedList = lib_json:encode(List),
 					case re:run(EncodedList, "\"options\":\\[\\]", [{capture, first, list}]) of

--- a/src/users.erl
+++ b/src/users.erl
@@ -39,16 +39,16 @@ init([]) ->
 %% @end
 -spec allowed_methods(ReqData::tuple(), State::string()) -> {list(), tuple(), string()}.
 allowed_methods(ReqData, State) ->
-        case api_help:parse_path(wrq:path(ReqData)) of                
-                [{"users","_search"}] ->
-                        {['POST','GET'], ReqData, State};
-                [{"users",_Id}] ->
-                        {['GET', 'PUT', 'DELETE'], ReqData, State};
-                [{"users"}] ->
-                        {['POST','GET'], ReqData, State};
-                [error] ->
-                        {[], ReqData, State}
-        end.
+    case api_help:parse_path(wrq:path(ReqData)) of                
+        [{"users","_search"}] ->
+            {['POST','GET'], ReqData, State};
+        [{"users",_Id}] ->
+            {['GET', 'PUT', 'DELETE'], ReqData, State};
+        [{"users"}] ->
+            {['POST','GET'], ReqData, State};
+        [error] ->
+            {[], ReqData, State}
+    end.
 
 
 
@@ -83,13 +83,18 @@ content_types_accepted(ReqData, State) ->
 %% @end
 -spec delete_resource(ReqData::tuple(), State::string()) -> {string(), tuple(), string()}.
 delete_resource(ReqData, State) ->
-        Id = id_from_path(ReqData),
-        case delete_resources_with_user_id(Id) of
-        {error,Reason} -> {{error,Reason}, wrq:set_resp_body("{\"error\":\""++ atom_to_list(Reason) ++ "\"}", ReqData), State};
+    Id = id_from_path(ReqData),
+    case delete_resources_with_user_id(Id) of
+        {error, {Code, Body}} -> 
+            ErrorString = api_help:generate_error(Body, Code),
+            {{halt, Code}, wrq:set_resp_body(ErrorString, ReqData), State};
         {ok} ->
             case erlastic_search:delete_doc(?INDEX,"user", Id) of
-                    {error,Reason} -> {{error,Reason}, wrq:set_resp_body("{\"error\":\""++ atom_to_list(Reason) ++ "\"}", ReqData), State};
-                    {ok,List} -> {true,wrq:set_resp_body(lib_json:encode(List),ReqData),State}
+                {error, {Code, Body}} -> 
+                    ErrorString = api_help:generate_error(Body, Code),
+                    {{halt, Code}, wrq:set_resp_body(ErrorString, ReqData), State};
+                {ok,List} -> 
+                    {true,wrq:set_resp_body(lib_json:encode(List),ReqData),State}
             end
     end.
 
@@ -104,15 +109,14 @@ delete_resource(ReqData, State) ->
 delete_resources_with_user_id(Id) ->
     Query = "user_id:" ++ Id, 
     case erlastic_search:search_limit(?INDEX, "resource", Query,500) of
-        {error,Reason} ->
-            erlang:display("\n\n\nThis is where the error is!\n\n\n"), 
-            {error,Reason};
+        {error,{Code, Body}} ->
+            {error,{Code, Body}};
         {ok,List} -> 
             case get_resources(List) of
                 [] -> {ok};
                 Streams ->
                     case delete_resources(Streams) of
-                        {error,Reason} -> {error, Reason};
+                        {error,{Code, Body}} -> {error, {Code, Body}};
                         {ok} -> {ok}
                     end
             end
@@ -146,11 +150,12 @@ get_resources([JSON | Tl]) ->
 delete_resources([]) -> {ok};
 delete_resources([ResourceId|Rest]) ->
     case resources:delete_streams_with_resource_id(ResourceId) of
-        {error,Reason} -> {error,Reason};
+        {error,{Code, Body}} -> 
+            {error,{Code, Body}};
         {ok} ->
             case erlastic_search:delete_doc(?INDEX,"resource", ResourceId) of
-                    {error,Reason} -> {error,Reason};
-                    {ok,_List} -> delete_resources(Rest)
+                {error,{Code, Body}} -> {error,{Code, Body}};
+                {ok,_List} -> delete_resources(Rest)
             end
     end.
 
@@ -164,23 +169,22 @@ delete_resources([ResourceId|Rest]) ->
 %% @end
 -spec put_user(ReqData::tuple(), State::string()) -> {true, tuple(), string()}.
 put_user(ReqData, State) ->
-        case id_from_path(ReqData) of
-                undefined -> {false ,wrq:set_resp_body("{\"error\":\"Incorrect user\"}", ReqData), State};
-                Id ->        
-                        %check if doc already exists
-                        case erlastic_search:get_doc(?INDEX, "user", Id) of
-                                {error, Reason} ->
-                                        {{error,Reason}, wrq:set_resp_body("{\"error\":\""++ atom_to_list(Reason) ++ "\"}", ReqData), State};
-                                {ok, List} ->
-                                        {UserJson,_,_} = api_help:json_handler(ReqData, State),
-					case erlastic_search:index_doc_with_id(?INDEX, "user", Id, UserJson) of
-						{error, Reason} ->
-							{{error,Reason}, wrq:set_resp_body("{\"error\":\""++ lib_json:encode(Reason) ++ "\"}", ReqData), State};
-						{ok, Json} ->
-							{true, wrq:set_resp_body(lib_json:encode(Json), ReqData), State}
-					end
-                        end
-        end.
+    Id = id_from_path(ReqData),
+    %check if doc already exists
+    case erlastic_search:get_doc(?INDEX, "user", Id) of
+        {error, {Code, Body}} -> 
+            ErrorString = api_help:generate_error(Body, Code),
+            {{halt, Code}, wrq:set_resp_body(ErrorString, ReqData), State};
+        {ok, List} ->
+            {UserJson,_,_} = api_help:json_handler(ReqData, State),
+            case erlastic_search:index_doc_with_id(?INDEX, "user", Id, UserJson) of
+                {error, {Code, Body}} -> 
+                    ErrorString = api_help:generate_error(Body, Code),
+                    {{halt, Code}, wrq:set_resp_body(ErrorString, ReqData), State};
+                {ok, Json} ->
+		            {true, wrq:set_resp_body(lib_json:encode(Json), ReqData), State}
+            end
+    end.
 
 
 %% @doc
@@ -194,16 +198,19 @@ put_user(ReqData, State) ->
 %% @end
 -spec process_post(ReqData::tuple(), State::string()) -> {true, tuple(), string()}.
 process_post(ReqData, State) ->
-        case api_help:is_search(ReqData) of
-                false ->
-                        {UserJson,_,_} = api_help:json_handler(ReqData, State),
-                        case erlastic_search:index_doc(?INDEX, "user", UserJson) of
-                                {error, Reason} -> {{error,Reason}, wrq:set_resp_body("{\"error\":\""++ atom_to_list(Reason) ++ "\"}", ReqData), State};
-                                {ok,List} -> {true, wrq:set_resp_body(lib_json:encode(List), ReqData), State}
-                        end;
-                true ->
-                        process_search(ReqData,State, post)                        
-        end.
+    case api_help:is_search(ReqData) of
+        false ->
+            {UserJson,_,_} = api_help:json_handler(ReqData, State),
+            case erlastic_search:index_doc(?INDEX, "user", UserJson) of
+                {error, {Code, Body}} -> 
+                    ErrorString = api_help:generate_error(Body, Code),
+                    {{halt, Code}, wrq:set_resp_body(ErrorString, ReqData), State};
+                {ok,List} -> 
+                    {true, wrq:set_resp_body(lib_json:encode(List), ReqData), State}
+            end;
+        true ->
+            process_search(ReqData,State, post)                        
+    end.
 
 
 %% @doc
@@ -213,39 +220,39 @@ process_post(ReqData, State) ->
 %% @end
 -spec get_user(ReqData::tuple(), State::string()) -> {list(), tuple(), string()}.
 get_user(ReqData, State) ->
-        case api_help:is_search(ReqData) of
-                false ->
-                        case id_from_path(ReqData) of
-                                undefined ->
-                                        % Get all users
-                                        case wrq:get_qs_value("size",ReqData) of 
-                                            undefined ->
-                                                Size = 100;
-                                            SizeParam ->
-                                                Size = list_to_integer(SizeParam)
-                                        end,
-                                        case erlastic_search:search_limit(?INDEX,"user","*:*",Size) of
-                                                {error, Reason} -> 
-                                                        {{error,Reason}, wrq:set_resp_body("{\"error\":\""++ atom_to_list(Reason) ++ "\"}", ReqData), State};
-					        {ok,JsonStruct} ->
-						       FinalJson = lib_json:get_list_and_add_id(JsonStruct),
-						       {FinalJson, ReqData, State}  
-                                        end;
-                                Id ->
-				        %% Get specific user
-                                        case erlastic_search:get_doc(?INDEX, "user", Id) of
-                                                {error, Reason} ->
-                                                        {{error,Reason}, wrq:set_resp_body("{\"error\":\""++ atom_to_list(Reason) ++ "\"}", ReqData), State};
-                                                {ok,JsonStruct} ->
-						        FinalJson = lib_json:get_and_add_id(JsonStruct),
-						        {FinalJson, ReqData, State} 
-
-
-                                        end
-                        end;
-                true ->                        
-                        process_search(ReqData,State, get)                        
-        end.
+    case api_help:is_search(ReqData) of
+        false ->
+            case id_from_path(ReqData) of
+                undefined ->
+                    % Get all users
+                    case wrq:get_qs_value("size",ReqData) of 
+                        undefined ->
+                            Size = 100;
+                        SizeParam ->
+                            Size = list_to_integer(SizeParam)
+                    end,
+                    case erlastic_search:search_limit(?INDEX,"user","*:*",Size) of
+                        {error, {Code, Body}} -> 
+                            ErrorString = api_help:generate_error(Body, Code),
+                            {{halt, Code}, wrq:set_resp_body(ErrorString, ReqData), State};
+					    {ok,JsonStruct} ->
+						    FinalJson = lib_json:get_list_and_add_id(JsonStruct, users),
+						    {FinalJson, ReqData, State}  
+                    end;
+                Id ->
+				    %% Get specific user
+                    case erlastic_search:get_doc(?INDEX, "user", Id) of
+                        {error, {Code, Body}} -> 
+                            ErrorString = api_help:generate_error(Body, Code),
+                            {{halt, Code}, wrq:set_resp_body(ErrorString, ReqData), State};
+                        {ok,JsonStruct} ->
+                            FinalJson = lib_json:get_and_add_id(JsonStruct),
+                            {FinalJson, ReqData, State} 
+                    end
+            end;
+        true ->                        
+            process_search(ReqData,State, get)                        
+    end.
 
 
 
@@ -261,16 +268,21 @@ process_search(ReqData, State, post) ->
         {struct, JsonData} = mochijson2:decode(Json),
         Query = api_help:transform(JsonData),
         case erlastic_search:search_limit(?INDEX, "user", Query, 10) of
-                {error,Reason} -> {{error,Reason}, wrq:set_resp_body("{\"error\":\""++ atom_to_list(Reason) ++ "\"}", ReqData), State};
-                {ok,List} -> {true, wrq:set_resp_body(lib_json:encode(List),ReqData),State}
-
+            {error, {Code, Body}} -> 
+                ErrorString = api_help:generate_error(Body, Code),
+                {{halt, Code}, wrq:set_resp_body(ErrorString, ReqData), State};
+            {ok,List} -> 
+                {true, wrq:set_resp_body(lib_json:encode(List),ReqData),State}
         end;
 process_search(ReqData, State, get) ->
         TempQuery = wrq:req_qs(ReqData),
         TransformedQuery = api_help:transform(TempQuery),
         case erlastic_search:search_limit(?INDEX, "user", TransformedQuery, 10) of
-                {error,Reason} -> {"{\"error\": \""++ atom_to_list(Reason) ++ "\"}", ReqData, State};
-                {ok,List} -> {lib_json:encode(List),ReqData,State} % May need to convert
+            {error, {Code, Body}} -> 
+                ErrorString = api_help:generate_error(Body, Code),
+                {{halt, Code}, wrq:set_resp_body(ErrorString, ReqData), State};
+            {ok,List} -> 
+                {lib_json:encode(List),ReqData,State} % May need to convert
         end.
 
 
@@ -279,16 +291,16 @@ process_search(ReqData, State, get) ->
 
 %% @doc
 %% Function: id_from_path/2
-%% Purpose: Retrieves the if from the path.
+%% Purpose: Retrieves the id from the path.
 %% Returns: Id
 %% @end
 -spec id_from_path(string()) -> string().
 id_from_path(RD) ->
-        case wrq:path_info(id, RD) of
-                undefined ->
-                        case string:tokens(wrq:disp_path(RD), "/") of
-                                ["users", Id] -> Id;
-                                _ -> undefined
-                        end;
-                Id -> Id
-        end.
+    case wrq:path_info(id, RD) of
+        undefined ->
+            case string:tokens(wrq:disp_path(RD), "/") of
+                ["users", Id] -> Id;
+                _ -> undefined
+            end;
+        Id -> Id
+    end.

--- a/test/datapoints_tests.erl
+++ b/test/datapoints_tests.erl
@@ -69,7 +69,7 @@ no_timestamp_test() ->
         check_returned_code(Response1, 200),
 		refresh(),
 		{ok,{_,_,Body}} = httpc:request(get, {"http://localhost:8000/streams/5/data/", []}, [], []),
-		ObjectList = lib_json:get_field(Body,"hits"),
+		ObjectList = lib_json:get_field(Body,"data"),
         ?assertEqual(true, lib_json:get_field(lists:nth(1,ObjectList),"timestamp") =/= undefined).
 
 %% @doc
@@ -112,7 +112,7 @@ get_non_existent_datapoint_test() ->
         Response1 = get_request(?DATAPOINTS_URL ++ "_search?_id=" ++ "nonexistent"),
 		{ok, Rest} = Response1,
 		{_,_,Result} = Rest,
-	    ?assertNotEqual(0, string:str(Result, "hits\":[]")).
+	    ?assertNotEqual(0, string:str(Result, "data\":[]")).
 
 post_request(URL, ContentType, Body) -> request(post, {URL, [], ContentType, Body}).
 get_request(URL) -> request(get, {URL, []}).
@@ -123,6 +123,7 @@ request(Method, Request) ->
 %% Function: refresh/0
 %% Purpose: Help function to find refresh the sensorcloud index
 %% Returns: {ok/error, {{Version, Code, Reason}, Headers, Body}}
+%% FIX: This relies on having a connection with elastic search on localhost:9200
 %% @end
 refresh() ->
     httpc:request(post, {"http://localhost:9200/sensorcloud/_refresh", [],"", ""}, [], []).

--- a/test/streams_tests.erl
+++ b/test/streams_tests.erl
@@ -66,7 +66,7 @@ get_stream_test() ->
 	{ok, {{_Version5, 200, _ReasonPhrase5}, _Headers5, Body5}} = httpc:request(get, {"http://localhost:8000/streams/_search?user_id=0", []}, [], []),
 	{ok, {{_Version6, 200, _ReasonPhrase6}, _Headers6, Body6}} = httpc:request(post, {"http://localhost:8000/streams/_search",[],"application/json", "{\"query\":{\"term\" : { \"test\" : \"get\" }}}"}, [], []),
 	% Test get for missing index
-	{ok, {{_Version7, 500, _ReasonPhrase7}, _Headers7, Body7}} = httpc:request(get, {"http://localhost:8000/streams/1", []}, [], []),
+	{ok, {{_Version7, 404, _ReasonPhrase7}, _Headers7, Body7}} = httpc:request(get, {"http://localhost:8000/streams/1", []}, [], []),
 	% Test delete
 	{ok, {{_Version8, 200, _ReasonPhrase8}, _Headers8, Body8}} = httpc:request(delete, {"http://localhost:8000/streams/" ++ lib_json:to_string(DocId1), []}, [], []),
 	{ok, {{_Version9, 200, _ReasonPhrase9}, _Headers9, Body9}} = httpc:request(delete, {"http://localhost:8000/streams/" ++ lib_json:to_string(DocId2), []}, [], []),
@@ -77,12 +77,11 @@ get_stream_test() ->
 	?assertEqual(true,lib_json:get_field(Body3,"creation_date") == list_to_binary(Date)),
 	?assertEqual(<<"get">>,lib_json:get_field(Body3,"test")),
 	?assertEqual(true,lib_json:get_field(Body3,"private") == <<"false">>),
-	?assertEqual(true,lib_json:field_value_exists(Body4,"hits[*].test", <<"get">>)),
+	?assertEqual(true,lib_json:field_value_exists(Body4,"streams[*].test", <<"get">>)),
 	?assertEqual(true,lib_json:field_value_exists(Body5,"hits.hits[*]._source.test", <<"get">>)),
 	?assertEqual(true,lib_json:get_field(Body5,"hits.total") >= 2), % Needed in case unempty elasticsearch
 	?assertEqual(true,lib_json:field_value_exists(Body5,"hits.hits[*]._source.test", <<"get">>)),
 	?assertEqual(true,lib_json:get_field(Body6,"hits.total") >= 2), % Needed in case unempty elasticsearch
-	?assertEqual(true,string:str(Body7,"not_found") =/= 0),
 	?assertEqual(true,lib_json:get_field(Body8,"_id") == DocId1),
 	?assertEqual(true,lib_json:get_field(Body9,"_id") == DocId2).
 
@@ -112,7 +111,7 @@ put_stream_test() ->
 	{ok, {{_Version7, 200, _ReasonPhrase7}, _Headers7, Body7}} = httpc:request(delete, {"http://localhost:8000/streams/" ++ lib_json:to_string(DocId1), []}, [], []),
 	{ok, {{_Version8, 200, _ReasonPhrase8}, _Headers8, Body8}} = httpc:request(delete, {"http://localhost:8000/streams/" ++ lib_json:to_string(DocId2), []}, [], []),
 	% Test update on missing doc
-	{ok, {{_Version9, 500, _ReasonPhrase9}, _Headers9, Body9}} = httpc:request(put, {"http://localhost:8000/streams/1", [], "application/json", "{\n\"test\" : \"put\"\n}"}, [], []),
+	{ok, {{_Version9, 404, _ReasonPhrase9}, _Headers9, Body9}} = httpc:request(put, {"http://localhost:8000/streams/1", [], "application/json", "{\n\"test\" : \"put\"\n}"}, [], []),
 	?assertEqual(<<"false">>,lib_json:get_field(Body5,"private")),
 	?assertEqual(true,lib_json:get_field(Body5,"private") =/= <<"true">>),
 	?assertEqual(true,lib_json:get_field(Body6,"private") =/= <<"false">>),
@@ -122,9 +121,8 @@ put_stream_test() ->
 	?assertEqual(true,lib_json:get_field(Body6,"test") == <<"put">>),
 	?assertEqual(true,lib_json:get_field(Body6,"test") =/= <<"get">>),
 	?assertEqual(true,lib_json:get_field(Body7,"_id") == DocId1),
-	?assertEqual(true,lib_json:get_field(Body8,"_id") == DocId2),
-	?assertEqual(true,string:str(Body9,"not_found") =/= 0).
-
+	?assertEqual(true,lib_json:get_field(Body8,"_id") == DocId2).
+	
 %% @doc
 %% Function: delete_stream_test/0
 %% Purpose: Test the delete_stream function by doing some HTTP requests
@@ -145,12 +143,10 @@ delete_stream_test() ->
 	{ok, {{_Version3, 200, _ReasonPhrase3}, _Headers3, Body3}} = httpc:request(delete, {"http://localhost:8000/streams/" ++ lib_json:to_string(DocId1), []}, [], []),
 	{ok, {{_Version4, 200, _ReasonPhrase4}, _Headers4, Body4}} = httpc:request(delete, {"http://localhost:8000/streams/" ++ lib_json:to_string(DocId2), []}, [], []),
 	% Test delete on missing index
-	{ok, {{_Version5, 500, _ReasonPhrase5}, _Headers5, Body5}} = httpc:request(delete, {"http://localhost:8000/streams/" ++ lib_json:to_string(DocId1), []}, [], []),
-	{ok, {{_Version6, 500, _ReasonPhrase6}, _Headers6, Body6}} = httpc:request(delete, {"http://localhost:8000/streams/" ++ lib_json:to_string(DocId2), []}, [], []),
+	{ok, {{_Version5, 404, _ReasonPhrase5}, _Headers5, Body5}} = httpc:request(delete, {"http://localhost:8000/streams/" ++ lib_json:to_string(DocId1), []}, [], []),
+	{ok, {{_Version6, 404, _ReasonPhrase6}, _Headers6, Body6}} = httpc:request(delete, {"http://localhost:8000/streams/" ++ lib_json:to_string(DocId2), []}, [], []),
 	?assertEqual(true,lib_json:get_field(Body3,"_id") == DocId1),
-	?assertEqual(true,lib_json:get_field(Body4,"_id") == DocId2),
-	?assertEqual(true,string:str(Body5,"not_found") =/= 0),
-	?assertEqual(true,string:str(Body6,"not_found") =/= 0).
+	?assertEqual(true,lib_json:get_field(Body4,"_id") == DocId2).
 
 %% @doc
 %% Function: create_doc_without_resource_test/0

--- a/test/users_tests.erl
+++ b/test/users_tests.erl
@@ -78,7 +78,7 @@ get_existing_user_test() ->
 -spec get_non_existing_user_test() -> ok | {error, term()}.
 get_non_existing_user_test() ->
 	Response1 = get_request(?USERS_URL ++ "non-existing-key"),
-	check_returned_code(Response1, 500).
+	check_returned_code(Response1, 404).
 
 
 %% @doc
@@ -161,11 +161,10 @@ delete_user_test() ->
 	{ok, {{_Version11, 200, _ReasonPhrase11}, _Headers11, Body11}} = httpc:request(get, {"http://localhost:8000/users/"++ lib_json:to_string(DocId) ++"/resources/"++ lib_json:to_string(DocId2) ++ "/streams", []}, [], []),
 	{ok, {{_Version12, 200, _ReasonPhrase12}, _Headers12, Body12}} = httpc:request(get, {"http://localhost:8000/users/"++ lib_json:to_string(DocId) ++"/resources/"++ lib_json:to_string(DocId3) ++ "/streams", []}, [], []),
 	% Delete a resource that doesn't exist
-	{ok, {{_Version13, 500, _ReasonPhrase13}, _Headers13, Body13}} = httpc:request(delete, {"http://localhost:8000/users/idthatdoesntexist", []}, [], []),
-	?assertEqual("{\"hits\":[]}",Body10),
-	?assertEqual("{\"hits\":[]}",Body11),
-	?assertEqual("{\"hits\":[]}",Body12),
-	?assertEqual("{\"error\":\"not_found\"}",Body13).
+	{ok, {{_Version13, 404, _ReasonPhrase13}, _Headers13, Body13}} = httpc:request(delete, {"http://localhost:8000/users/idthatdoesntexist", []}, [], []),
+	?assertEqual("{\"resources\":[]}",Body10),
+	?assertEqual("{\"streams\":[]}",Body11),
+	?assertEqual("{\"streams\":[]}",Body12).
 
 	
 
@@ -180,7 +179,7 @@ delete_user_test() ->
 -spec delete_non_existing_user_test() -> ok | {error, term()}.
 delete_non_existing_user_test() ->	
 	Response1 = delete_request(?USERS_URL++"non-existing-key"),
-	check_returned_code(Response1, 500).
+	check_returned_code(Response1, 404).
 
 
 %% @doc


### PR DESCRIPTION
Updated API to follow the guidelines set in issue #83 
if a resource does not exist when a specific ID is asked for, a 404 is generated.
If a call to list all the resources of a specific type for example localhost/user/1/resources/1/streams , 
a JSON-object with the pattern {<resource_type>: [<list of objects>]}
In the above example, the object {"streams": []} would be returned if there were no streams belonging to resource with ID 1
