### PR TITLE
Sp6.sc1.history search list of streams

### DIFF
--- a/priv/dispatch.conf
+++ b/priv/dispatch.conf
@@ -43,6 +43,7 @@
 
 %%SEARCH
 {["_search"], search, []}.
+{["_history"], search, []}.
 
 %%ANALYSE
 {["users", 'userid', "resources", 'resourceid', "streams", 'streamid', "_analyse"], analyse, []}.

--- a/src/search.erl
+++ b/src/search.erl
@@ -78,9 +78,9 @@ get_search(ReqData, State) ->
             Values ->
                 {NrValues, _} = string:to_integer(Values)
     end,
-    case wrq:get_qs_value("streamid",ReqData) of 
+    case wrq:get_qs_value("stream_id",ReqData) of 
             undefined ->
-                ErrorString = api_help:generate_error(<<"Invalid streamid">>, 405),
+                ErrorString = api_help:generate_error(<<"Invalid stream_id">>, 405),
                 {{halt, 405}, wrq:set_resp_body(ErrorString, ReqData), State};
             StreamIds ->
                 IdList = string:tokens(StreamIds, ","),
@@ -182,7 +182,7 @@ get_history([Head|Rest], NrValues, Acc) ->
                 ErrorString = api_help:generate_error(Body, Code),
                 IdAndDataJson = "{\"id\":\""++Head++"\",\"data\":{\"error\": \""++ErrorString++"\"}";
         {ok,JsonStruct} ->
-                IdAndDataJson = parse_datapoints(lib_json:get_field(JsonStruct, "hits.hits"),"{\"id\":\""++Head++"\",\"data\":[]}")  
+                IdAndDataJson = parse_datapoints(lib_json:get_field(JsonStruct, "hits.hits"),"{\"stream_id\":\""++Head++"\",\"data\":[]}")  
     end,
     get_history(Rest, NrValues, lib_json:add_value(Acc,"history",IdAndDataJson)).
 

--- a/test/search_tests.erl
+++ b/test/search_tests.erl
@@ -1,4 +1,4 @@
-%% @author Jose Arias
+%% @author Jose Arias, Andreas Moregård Haubenwaller
 %% [www.csproj13.student.it.uu.se]
 %% @version 1.0
 %% @copyright [Copyright information]
@@ -24,6 +24,17 @@
 
 init_test() ->
     inets:start().
+
+%% @doc
+%% Function: get_search_test/0
+%% Purpose: Test the get_search function by doing some HTTP requests
+%% Returns: ok | {error, term()}
+%% @end
+get_search_test() ->
+    {ok, {{_Version1, 405, _ReasonPhrase1}, _Headers1, Body1}} = httpc:request(get, {"http://localhost:8000/_history", []}, [], []),
+    {ok, {{_Version2, 501, _ReasonPhrase2}, _Headers2, Body2}} = httpc:request(get, {"http://localhost:8000/_search", []}, [], []),
+    {ok, {{_Version3, 200, _ReasonPhrase3}, _Headers3, Body3}} = httpc:request(get, {"http://localhost:8000/_history?stream_id=id_that_doesnt_exist", []}, [], []),
+    ?assertEqual([],lib_json:get_field(Body3,"history[0].data")).
 
 
 

--- a/test/suggest_tests.erl
+++ b/test/suggest_tests.erl
@@ -123,6 +123,7 @@ update_resource_test() ->
 	?assertEqual(<<"test2">>, lib_json:get_field_value(Body2, "suggestions[0].payload.streams[*].tags",<<"test2">>)),
 	{ok, {{_Version21, 200, _ReasonPhrase21}, _Headers21, _Body21}} = httpc:request(put, {"http://localhost:8000/resources/"++lib_json:to_string(Id), [],"application/json", "{\"model\" : \"testupdate\",\"tags\" : \"newtag\"}"}, [], []),
 	api_help:refresh(),
+	timer:sleep(1000),
 	{ok, {_, _ ,Body3}} = get_request(?SUGGEST_URL++"testupdate"),
 	?assertEqual(<<"newtag">>,lib_json:get_field(Body3, "suggestions[0].payload.tags")),
 	?assertEqual(true, lib_json:field_value_exists(Body3, "suggestions[0].payload.streams[*].tags",<<"test_tag">>)),

--- a/test/suggest_tests.erl
+++ b/test/suggest_tests.erl
@@ -123,7 +123,6 @@ update_resource_test() ->
 	?assertEqual(<<"test2">>, lib_json:get_field_value(Body2, "suggestions[0].payload.streams[*].tags",<<"test2">>)),
 	{ok, {{_Version21, 200, _ReasonPhrase21}, _Headers21, _Body21}} = httpc:request(put, {"http://localhost:8000/resources/"++lib_json:to_string(Id), [],"application/json", "{\"model\" : \"testupdate\",\"tags\" : \"newtag\"}"}, [], []),
 	api_help:refresh(),
-	timer:sleep(1000),
 	{ok, {_, _ ,Body3}} = get_request(?SUGGEST_URL++"testupdate"),
 	?assertEqual(<<"newtag">>,lib_json:get_field(Body3, "suggestions[0].payload.tags")),
 	?assertEqual(true, lib_json:field_value_exists(Body3, "suggestions[0].payload.streams[*].tags",<<"test_tag">>)),


### PR DESCRIPTION
Added the _history call.

Example usage: "localhost:8000/_history?stream_id=1,2,3"

That will return the json object:
{
    "history": [
        {"stream_id":"1", "data":[{"timestamp":"TIMESTAMP1", "value": VALUE1}]},
        {"stream_id":"2", "data":[{"timestamp":"TIMESTAMP2", "value": VALUE2}]},
        {"stream_id":"3", "data":[{"timestamp":"TIMESTAMP3", "value": VALUE3}]}
    ]
}

Assuming that stream 1, 2 and 3 have one datapoint each.
