### PR TITLE
Sp7.sc3.start virtual streams when starting engine

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,7 +139,7 @@ test_vstreams: compile
 	-@mkdir test-results
 	curl -XDELETE localhost:9200/sensorcloud
 	curl -XPUT localhost:9200/sensorcloud
-	$(ERL) $(ERL_PA_FOLDERS) $(ERL_CONFIG) $(ERL_BOOT) -sname engine -eval 'test:run(virtual_stream_process)'
+	$(ERL) $(ERL_PA_FOLDERS) $(ERL_CONFIG) $(ERL_BOOT) -sname engine -eval 'test:run(gen_virtual_stream_process)'
 
 
 ### Command: make docs

--- a/src/engine.erl
+++ b/src/engine.erl
@@ -48,6 +48,19 @@ stop() ->
     application:stop(mochiweb),
     application:stop(crypto),
     application:stop(inets),
-	exit(whereis(polling_monitor), "stop"),
-	exit(whereis(polling_supervisor), "stop"),
+    case whereis(polling_monitor) of
+        undefined -> ok;
+        P_M_Pid ->
+            exit(P_M_Pid, "stop")
+    end,
+    case whereis(polling_supervisor) of
+        undefined -> ok;
+        P_S_Pid ->
+            exit(P_S_Pid, "stop")
+    end,
+    case whereis(vstream_sup) of
+        undefined -> ok;
+        V_S_Pid ->
+            exit(V_S_Pid, "stop")
+    end,
     Res.

--- a/src/engine_sup.erl
+++ b/src/engine_sup.erl
@@ -66,6 +66,7 @@ init([]) ->
            permanent, 5000, worker, [mochiweb_socket_server]},
 	polling_system:start_link(),
     virtual_stream_process_supervisor:start_link(),
+    virtual_stream_process_supervisor:start_processes(),
     Processes = [Web],
     {ok, { {one_for_one, 10, 10}, Processes} }.
 

--- a/src/engine_sup.erl
+++ b/src/engine_sup.erl
@@ -65,6 +65,7 @@ init([]) ->
            {webmachine_mochiweb, start, [WebConfig]},
            permanent, 5000, worker, [mochiweb_socket_server]},
 	polling_system:start_link(),
+    virtual_stream_process_supervisor:start_link(),
     Processes = [Web],
     {ok, { {one_for_one, 10, 10}, Processes} }.
 

--- a/src/parser.erl
+++ b/src/parser.erl
@@ -49,13 +49,13 @@ parseJson(Parser, Data, Time) ->
 				  end,
 	FieldValue2 = case is_integer(Res) of
 		true->
-			{"value",integer_to_binary(Res)};
+			{"value",Res};
 		_->
 			case is_float(Res) of
 				true->
-					{"value",float_to_binary(Res)};
+					{"value",Res};
 				_ ->
-					{"value",list_to_binary(Res)}
+					{"value",list_to_float(Res)}
 			end
 	end,
 	TimeStamp = case Time of

--- a/src/poller.erl
+++ b/src/poller.erl
@@ -131,15 +131,14 @@ handle_info({probe}, State)->
 										parser:parseText(Parser, Body, make_stamp(TimeList));
 									_ ->
 										%% the input type of json is wrong
-										erlang:display("the data type user provided is not correct!!")
+										{error, "Invalid data type!"}
 								end,
-					case FinalData == true of
-						false->
+					case FinalData of
+						{error, ErrMsg}->erlang:display(ErrMsg);
+						_->
 							amqp_channel:cast(State#state.channel,
 					  							#'basic.publish'{exchange = State#state.exchange},
-					  							#amqp_msg{payload = list_to_binary(FinalData)});
-						_->
-							continue
+					  							#amqp_msg{payload = list_to_binary(FinalData)})
 					end;
 
 				_ ->
@@ -183,6 +182,7 @@ terminate(_Reason, State)->
 %% Returns: string()
 %% @end
 -spec make_stamp(list()) -> string().
+make_stamp([])->[];
 make_stamp(TimeList)->
 	Day = lists:nth(2, TimeList),
 	Month = case lists:nth(3, TimeList) of

--- a/src/pubsub/gen_virtual_stream_process.erl
+++ b/src/pubsub/gen_virtual_stream_process.erl
@@ -489,7 +489,7 @@ get_latest_value_for_streams([{Type, Id} | T]) ->
 -spec apply_function(VStreamId :: binary(),
 					 Function :: atom(),
 					 List :: [{Id :: string(),
-							   DataPoint :: json() | undefined}]) -> number().
+							   DataPoint :: json() | undefined}]) -> [number()].
 %% ====================================================================
 apply_function(_VStreamId, _Function, []) -> [none];
 apply_function(VStreamId, Function, DataPoints) ->

--- a/src/pubsub/gen_virtual_stream_process.erl
+++ b/src/pubsub/gen_virtual_stream_process.erl
@@ -87,13 +87,6 @@ start_link(VStreamId, InputIds, Function) ->
 	Timeout :: non_neg_integer() | infinity.
 %% ====================================================================
 init([VStreamId, InputIds, Function]) ->
-	
-	erlang:display("Got Id: " ++ VStreamId),
-	erlang:display("~nGot InputIds: "),
-	erlang:display(InputIds),
-	erlang:display("~nGot Function: "),
-	erlang:display(Function),
-
 	%% Trap exits from parent
 	process_flag(trap_exit, true),
 	

--- a/src/pubsub/gen_virtual_stream_process.erl
+++ b/src/pubsub/gen_virtual_stream_process.erl
@@ -1,0 +1,427 @@
+%% @author Anders Steinrud, Gabriel Tholsgård <gath5951@student.uu.se>
+%%   [www.csproj13.student.it.uu.se]
+%% @version 1.0
+%% @copyright [Copyright information]
+%%
+%% @doc == gen_virtual_stream_process ==
+%% Represents a gen_server of a virtual stream process which subscribes to
+%% data points from the pub/sub system for specified streams/virtual streams
+%% and publish it back into the pub/sub system for the represented virtual
+%% stream after applying the specified function with the data points as
+%% arguments. 
+%%
+%% @end
+
+-module(gen_virtual_stream_process).
+-behaviour(gen_server).
+
+-include_lib("erlastic_search.hrl").
+-include_lib("amqp_client.hrl").
+-include_lib("pubsub.hrl").
+-include_lib("common.hrl").
+-include_lib("json.hrl").
+-include_lib("debug.hrl").
+
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2, code_change/3]).
+
+%% ====================================================================
+%% API functions
+%% ====================================================================
+-export([]).
+
+
+%% ====================================================================
+%% Behavioural functions 
+%% ====================================================================
+
+
+
+%% spec of record state:
+%% {string(), [{atom(),string()}], binary(), {pid(), pid(), pid()}, atom()}
+-record(state, {vstreamid, datapoints, exchange, network, function, log}).
+
+
+
+%% init/1
+%% ====================================================================
+%% @doc <a href="http://www.erlang.org/doc/man/gen_server.html#Module:init-1">gen_server:init/1</a>
+%% Args: Data - A list of length three.
+%%              First element is the virtual stream id as a string.
+%%              Second element is a list of streams to subscribe to in the
+%%              format: [{Type, Id}]
+%%				where Type is the atom stream or vstream and Id is a string.
+%%				Third element is the function to apply as a atom,
+%%				i.e sum, max, min, avg.
+-spec init(Args :: Data) -> Result when
+	Data :: iolist(),
+	Result :: {ok, State}
+			| {ok, State, Timeout}
+			| {ok, State, hibernate}
+			| {stop, Reason :: term()}
+			| ignore,
+	State :: record(),
+	Timeout :: non_neg_integer() | infinity.
+%% ====================================================================
+init([VStreamId, InputIds, Function]) ->
+	
+	%% Exchange name binarys.
+	InputExchanges = create_input_exchanges(InputIds),
+	VStreamExchange = list_to_binary("vstreams." ++ VStreamId),
+	
+	%% Connect.
+	{ok, Connection} =
+		amqp_connection:start(#amqp_params_network{}),
+	
+	%% Open In and OUT channels.
+	{ok, ChannelIn} = amqp_connection:open_channel(Connection),
+	{ok, ChannelOut} = amqp_connection:open_channel(Connection),
+	
+	%% Declare INPUT queues and subscribe.
+	subscribe(ChannelIn, InputExchanges),
+	
+	%% Declare OUTPUT exchange.
+	amqp_channel:call(ChannelOut,
+					  #'exchange.declare'{exchange = VStreamExchange,
+										  type = <<"fanout">>}),
+
+	%% Needed for the RabbitMQ to have time to set up the system.
+	timer:sleep(1000),
+	
+	%% Get the latest value for each datapoint.
+	DataPoints = get_latest_value_for_streams(InputIds),
+	
+	%% Create state
+	State = #state{vstreamid=VStreamId,
+				   datapoints = DataPoints,
+				   exchange = VStreamExchange,
+				   network = {Connection, ChannelIn, ChannelOut},
+				   function = Function,
+				   log = []},
+    {ok, State}.
+
+
+%% handle_call/3
+%% ====================================================================
+%% @doc <a href="http://www.erlang.org/doc/man/gen_server.html#Module:handle_call-3">gen_server:handle_call/3</a>
+-spec handle_call(Request :: term(), From :: {pid(), Tag :: term()}, State :: term()) -> Result when
+	Result :: {reply, Reply, NewState}
+			| {reply, Reply, NewState, Timeout}
+			| {reply, Reply, NewState, hibernate}
+			| {noreply, NewState}
+			| {noreply, NewState, Timeout}
+			| {noreply, NewState, hibernate}
+			| {stop, Reason, Reply, NewState}
+			| {stop, Reason, NewState},
+	Reply :: term(),
+	NewState :: term(),
+	Timeout :: non_neg_integer() | infinity,
+	Reason :: term().
+%% ====================================================================
+%% Not used by our server
+handle_call(Request, _From, State) ->
+    Reply = ok,
+    {reply, Reply, State}.
+
+
+
+%% handle_cast/2
+%% ====================================================================
+%% @doc <a href="http://www.erlang.org/doc/man/gen_server.html#Module:handle_cast-2">gen_server:handle_cast/2</a>
+-spec handle_cast(Request :: term(), State :: term()) -> Result when
+	Result :: {noreply, NewState}
+			| {noreply, NewState, Timeout}
+			| {noreply, NewState, hibernate}
+			| {stop, Reason :: term(), NewState},
+	NewState :: term(),
+	Timeout :: non_neg_integer() | infinity.
+%% ====================================================================
+%% Not used by our server
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+
+%% handle_info/2
+%% ====================================================================
+%% @doc <a href="http://www.erlang.org/doc/man/gen_server.html#Module:handle_info-2">gen_server:handle_info/2</a>
+-spec handle_info(Info :: timeout | term(), State :: record()) -> Result when
+	Result :: {noreply, NewState}
+			| {noreply, NewState, Timeout}
+			| {noreply, NewState, hibernate}
+			| {stop, Reason :: term(), NewState},
+	NewState :: record(),
+	Timeout :: non_neg_integer() | infinity.
+%% ====================================================================
+handle_info({#'basic.deliver'{}, #amqp_msg{payload = Body}},
+			State = #state{vstreamid = VStreamId, datapoints = DataPoints,
+						   exchange = VStreamExchange, network = Net,
+						   function = Function}) ->
+	Data = binary_to_list(Body),
+	case erlson:is_json_string(Data) of
+		%% New value from the source as a Json
+		true ->
+			Id = binary_to_list(lib_json:get_field(Data, "stream_id")),
+			%% TODO Check whether it is a virtual stream or a stream before
+			%%      replacing the key, since they can have the same key.
+			NewDataPoints = lists:keyreplace(Id, 1, DataPoints, {Id, Data}),
+			
+			%% Apply function to the new values
+			[Value] = apply_function(list_to_binary(VStreamId),
+									 Function, NewDataPoints),
+			
+			%% Create timestamp to avoid issues with asynchronus datapoints.
+			Timestamp = ?TIME_NOW(erlang:localtime()),
+			
+			%% Create new datapoint message
+			Msg = lib_json:replace_field(Value, "timestamp",
+										 list_to_binary(Timestamp)),
+			
+			%% Store value in ES
+			case erlastic_search:index_doc(?ES_INDEX, "vsdatapoint", Msg) of
+				{error, Reason} ->
+					erlang:display({error, Reason}),
+					{noreply, State};
+				{ok, _} ->
+					%% Publish the calculated value
+					ChannelOut = element(3, Net),
+					send(ChannelOut, VStreamExchange, list_to_binary(Msg)),
+					{noreply, State#state{datapoints = NewDataPoints}}
+			end;
+		_ ->
+			{noreply, State}
+	end;
+
+handle_info(quit, State) ->
+	{stop, normal, State};
+			
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+
+%% terminate/2
+%% ====================================================================
+%% @doc <a href="http://www.erlang.org/doc/man/gen_server.html#Module:terminate-2">gen_server:terminate/2</a>
+-spec terminate(Reason, State :: term()) -> Any :: term() when
+	Reason :: normal
+			| shutdown
+			| {shutdown, term()}
+			| term().
+%% ====================================================================
+
+terminate(Reason, #state{network = Net}) when Net /= undefined ->
+	{Connection, ChannelIn, ChannelOut} = Net,
+	amqp_channel:close(ChannelIn),
+	amqp_channel:close(ChannelOut),
+	amqp_connection:close(Connection),
+	ok;
+
+terminate(Reason, State) ->
+    ok.
+
+
+%% code_change/3
+%% ====================================================================
+%% @doc <a href="http://www.erlang.org/doc/man/gen_server.html#Module:code_change-3">gen_server:code_change/3</a>
+-spec code_change(OldVsn, State :: term(), Extra :: term()) -> Result when
+	Result :: {ok, NewState :: term()} | {error, Reason :: term()},
+	OldVsn :: Vsn | {down, Vsn},
+	Vsn :: term().
+%% ====================================================================
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+
+
+
+
+
+
+
+
+%% ====================================================================
+%% Internal functions
+%% ====================================================================
+
+
+%% send/3
+%% ====================================================================
+%% @doc
+%% Function: send/3
+%% Purpose: Used to publish a message into specified exchange in the pub/sub
+%%          system on the specified channel.
+%% Args: Channel - The channel on which we publish,
+%%       Exchange - The exchange we publish to,
+%%       Message - The message that we want to publish.
+%% Returns: ok.
+%% Side effects: Publish the message 'Message' into the exchange 'Exchange'.
+%%
+%% @end
+%% ====================================================================
+-spec send(Channel :: pid(), Exchange :: binary(), Message :: binary()) -> ok.
+send(Channel, Exchange, Message) ->
+	amqp_channel:cast(Channel,
+					  #'basic.publish'{exchange = Exchange},
+					  #amqp_msg{payload = Message}).
+
+
+
+
+
+
+
+%% create_input_exchanges/1
+%% ====================================================================
+%% @doc
+%% Function: create_input_exchanges/1
+%% Purpose: Used to create names of exchanges from a list of streams and
+%%          virtual streams, i.e [{stream, Id}, {vstream, Id}].
+%% Args: List - A list of streams, i.e [{stream, Id}, {vstream, Id}].
+%% Returns: [] | [Exchange]
+%% @end
+%% ====================================================================
+-spec create_input_exchanges(List) -> [] | [Exchange] when
+		  List :: [StreamInfo],
+          StreamInfo :: {Type, Id},
+          Type :: atom(),
+          Id :: string(),
+          Exchange :: binary().
+create_input_exchanges(List) ->
+	create_input_exchanges(List, []).
+
+%% create_input_exchanges/2
+%% ====================================================================
+%% @doc
+%% Function: create_input_exchanges/2
+%% Purpose: Used to create names of exchanges from a list of streams and
+%%          virtual streams, i.e [{stream, Id}, {vstream, Id}].
+%% Args: List - A list of streams, i.e [{stream, Id}, {vstream, Id}],
+%%       Exchanges - The list to store the created exchanges in.
+%% Returns: Exchanges | [Exchange] ++ Exchanges
+%% @end
+%% ====================================================================
+-spec create_input_exchanges(List, Exchanges) ->
+		  Exchanges
+		| [Exchange | Exchanges] when
+		  List :: [StreamInfo],
+          Exchanges :: list(),
+          StreamInfo :: {Type, Id},
+          Type :: atom(),
+          Id :: string(),
+          Exchange :: binary().
+create_input_exchanges([], Exchanges) -> Exchanges;
+create_input_exchanges([{Type, Id} | InputIds], Exchanges) when
+  Type =:= stream; Type =:= vstream ->
+	Exchange = list_to_binary(atom_to_list(Type) ++ "s." ++ Id),
+	create_input_exchanges(InputIds, [Exchange | Exchanges]).
+
+
+
+
+
+
+
+%% subscribe/2
+%% ====================================================================
+%% @doc
+%% Function: subscribe/2
+%% Purpose: Used to subscribe to the given exchanges on the given channel.
+%% Args: ChannelIn - The channel on which communication to the server occurs,
+%%       InputExchanges - The list of exchanges to subscribe to.
+%% Returns: ok
+%% Side-effects: Creates one queue in RabbitMQ for each exchange and binds it
+%%               to the exchange.
+%% @end
+%% ==================================================================== 
+-spec subscribe(ChannelIn :: pid(), InputExchanges :: [binary()]) -> ok.
+subscribe(_, []) -> ok;
+subscribe(ChannelIn, [InputExchange | InputExchanges]) ->
+	%% Declare INPUT queues
+	amqp_channel:call(ChannelIn,
+					  #'exchange.declare'{exchange = InputExchange,
+										  type = <<"fanout">>}),
+	#'queue.declare_ok'{queue = QueueIn} =
+						   amqp_channel:call(
+							 ChannelIn,
+							 #'queue.declare'{exclusive = true}),
+	amqp_channel:call(ChannelIn, #'queue.bind'{exchange = InputExchange,
+											   queue = QueueIn}),
+	amqp_channel:subscribe(ChannelIn,
+						   #'basic.consume'{queue = QueueIn, no_ack = true},
+						   self()),
+	receive
+		#'basic.consume_ok'{} -> ok
+	end,
+	subscribe(ChannelIn, InputExchanges).
+
+
+
+
+
+
+%% get_latest_value_for_streams/1
+%% ====================================================================
+%% @doc
+%% Function: get_latest_value_for_streams/1
+%% Purpose: Used to get the latest value for each stream/virtual stream
+%% in the provided list.
+%% Args: List - The list of streams and virtual streams.
+%% Returns: [] | [{Id, Value}].
+%% @end
+%% ====================================================================
+-spec get_latest_value_for_streams(List :: [{Type :: atom(), Id :: string()}])
+	-> [] | [{Id :: string(), Value :: json() | undefined}].
+get_latest_value_for_streams([]) -> [];
+get_latest_value_for_streams([{Type, Id} | T]) ->
+	JsonQuery = "{\"query\" : {\"term\" : {\"stream_id\" : \"" ++ Id ++ "\"}},"
+					++ "\"sort\" : [{\"timestamp\" : {\"order\" : \"desc\"}}],"
+					++ "\"size\" : 1}",
+	DataPointType = case Type of
+						stream -> "datapoint";
+						vstream -> "vsdatapoint"
+					end,
+	case erlastic_search:search_json(#erls_params{}, ?ES_INDEX,
+									 DataPointType, JsonQuery) of
+		{ok, Result} ->
+			Datapoint = lib_json:get_field(Result, "hits.hits"),
+			case Datapoint of
+				[] -> [{Id, undefined} | get_latest_value_for_streams(T)];
+				[Json] ->
+					Value = lib_json:get_field(Json, "_source"),
+					[{Id, Value} | get_latest_value_for_streams(T)]
+			end;
+		{error, _} -> get_latest_value_for_streams(T)
+	end.
+
+
+
+
+
+%% apply_function/3
+%% ====================================================================
+%% @doc
+%% Function: apply_function/3
+%% Purpose: Applies the specified predefined function
+%%          with the list as its argument.
+%% Args: VStreamId - The virtual stream id for which
+%%		 			 we are doing the calculation,
+%%		 Function - Specifier of a predefined function,
+%%       List - List of datapoints for streams and virtual streams.
+%% Returns: Value of the predefined function.
+%% Side effects: Applies a predefined function
+%% @end
+%% ====================================================================
+-spec apply_function(VStreamId :: binary(),
+					 Function :: atom(),
+					 List :: [{Id :: string(),
+							   DataPoint :: json() | undefined}]) -> number().
+apply_function(_VStreamId, _Function, []) -> 0;
+apply_function(VStreamId, Function, DataPoints) ->
+	DataList =
+		lists:foldr(fun({_, Data}, Acc) ->
+							case Data of
+								undefined -> Acc;
+								_ -> [Data|Acc]
+							end
+					end,
+					[], DataPoints),
+	vs_func_lib:Function([DataList], VStreamId).
+

--- a/src/pubsub/virtual_stream_process.erl
+++ b/src/pubsub/virtual_stream_process.erl
@@ -1,4 +1,4 @@
-%% @author Anders Steinrud, Gabriel Tholsgård
+%% @author Anders Steinrud, Gabriel Tholsgård <gath5951@student.uu.se>
 %%   [www.csproj13.student.it.uu.se]
 %% @version 1.0
 %% @copyright [Copyright information]
@@ -198,6 +198,8 @@ send(Channel, Exchange, Message) ->
 	amqp_channel:cast(Channel,
 					  #'basic.publish'{exchange = Exchange},
 					  #amqp_msg{payload = Message}).
+
+
 
 
 

--- a/src/pubsub/virtual_stream_process_supervisor.erl
+++ b/src/pubsub/virtual_stream_process_supervisor.erl
@@ -1,0 +1,58 @@
+%% @author Gabriel Tholsgård <gath5951@student.uu.se>
+%%   [www.csproj13.student.it.uu.se]
+%% @version 1.0
+%% @copyright [Copyright information]
+%%
+%% @doc == virtual_stream_process_supervisor ==
+%% This module represents a virtual stream process supervisor which
+%% initializes all virtual stream processes and puts them under its
+%% supervision. 
+%%
+%% @end
+
+-module(virtual_stream_process_supervisor).
+-behaviour(supervisor).
+-export([init/1]).
+
+%% ====================================================================
+%% API functions
+%% ====================================================================
+-export([]).
+
+
+
+%% ====================================================================
+%% Behavioural functions 
+%% ====================================================================
+
+%% init/1
+%% ====================================================================
+%% @doc <a href="http://www.erlang.org/doc/man/supervisor.html#Module:init-1">supervisor:init/1</a>
+-spec init(Args :: term()) -> Result when
+	Result :: {ok, {SupervisionPolicy, [ChildSpec]}} | ignore,
+	SupervisionPolicy :: {RestartStrategy, MaxR :: non_neg_integer(), MaxT :: pos_integer()},
+	RestartStrategy :: one_for_all
+					 | one_for_one
+					 | rest_for_one
+					 | simple_one_for_one,
+	ChildSpec :: {Id :: term(), StartFunc, RestartPolicy, Type :: worker | supervisor, Modules},
+	StartFunc :: {M :: module(), F :: atom(), A :: [term()] | undefined},
+	RestartPolicy :: permanent
+				   | transient
+				   | temporary,
+	Modules :: [module()] | dynamic.
+%% ====================================================================
+init([]) ->
+	%% TODO Get all virtual streams in a list
+    AChild = {'AName',{'AModule',start_link,[]},
+	      permanent,2000,worker,['AModule']},
+    {ok,{{simple_one_for_one,5,60}, [AChild]}}.
+
+%% SupervisionPolicy: {simple_one_for_one, 5, 60}  -- simple_one_for_one because it can create children dynamically but kills are harder.
+%% ChildSpec: {VStreamId, {virtual_stream_process, start_link, []}, transient, brutal_kill, worker, [virtual_stream_process]}.
+
+%% ====================================================================
+%% Internal functions
+%% ====================================================================
+
+

--- a/src/pubsub/virtual_stream_process_supervisor.erl
+++ b/src/pubsub/virtual_stream_process_supervisor.erl
@@ -22,7 +22,7 @@
 %% ====================================================================
 %% API functions
 %% ====================================================================
--export([start_link/0, start_processes/0]).
+-export([start_link/0, start_processes/0, add_child/3]).
 
 
 
@@ -88,6 +88,35 @@ start_processes() ->
 			end
 	end.
 
+
+
+
+%% add_child/3
+%% ====================================================================
+%% @doc
+%% Function: add_child/3
+%% Purpose: Add a virtual stream process under supervision.
+%% Args: Id - The id of the virtual stream to start
+%%       InputIds - The list of streams to subscribe to, in the form:
+%%                  [{Type, SId}, ...] where SId is the Id of the
+%%                  stream and Type is either the atom stream or vstream.
+%%       Function - The aggregation function to apply 
+%% Return: ok | {error, Reason}.
+%% Side effects: Starts a virtual stream processes under supervision.
+%% @end
+-spec add_child(Id :: string(), InputIds :: [StreamInfo], Function :: atom()) ->
+	ok | {error, string()} when
+		StreamInfo :: {Type, Id :: string()},
+		Type :: stream | vstream.
+%% ====================================================================
+add_child(Id, InputIds, Function) ->
+	case whereis(vstream_sup) of
+		undefined ->
+			{error, "Start the supervisor first"};
+		_ ->
+			_ = supervisor:start_child(vstream_sup, [Id, InputIds, Function]),
+			ok
+	end.
 
 
 

--- a/src/stream_publisher.erl
+++ b/src/stream_publisher.erl
@@ -36,7 +36,7 @@ main(Id, Val) ->
     amqp_channel:cast(Channel,
                       #'basic.publish'{exchange = Exchange},
                       #amqp_msg{payload = Message}),
-    io:format(" [x] Sent to ~p:~p~n", [StreamId, Message]),
+    io:format(" [x] Sent to ~p:~p~n", ["streams." ++ StreamId, Message]),
     ok = amqp_channel:close(Channel),
     ok = amqp_connection:close(Connection),
     ok.

--- a/test/gen_virtual_stream_process_tests.erl
+++ b/test/gen_virtual_stream_process_tests.erl
@@ -8,7 +8,7 @@
 %%
 %% @end
 
--module(virtual_stream_process_tests).
+-module(gen_virtual_stream_process_tests).
 
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("amqp_client.hrl").
@@ -31,7 +31,13 @@
 %% ====================================================================
 
 
-
+%% virtual_stream_process_test_/0
+%% ====================================================================
+%% @doc
+%% Function: virtual_stream_process_test_/0
+%% Purpose: Runs all the tests with extended timeouts
+%% @end
+%% ====================================================================
 virtual_stream_process_test_() ->
 	S = fun() -> ok end,
 	C = fun(_) -> ok end,
@@ -52,13 +58,11 @@ virtual_stream_process_test_() ->
 %% @end
 -spec start_and_terminate(_) -> ok | {error, term()}.
 start_and_terminate(_) ->
-	Pid = spawn(virtual_stream_process, create, ["1", [], "test"]),
+	{ok, Pid} = gen_virtual_stream_process:start_link("1", [], sum),
 	Info1 = is_process_alive(Pid),
-	%%?assertNotEqual(undefined, process_info(Pid)),
 	Pid ! quit,
 	timer:sleep(1500),
 	Info2 = is_process_alive(Pid),
-	%%?assertEqual(undefined, process_info(Pid)).
 	[?_assertEqual(true, Info1),
 	 ?_assertEqual(false, Info2)].
 
@@ -322,7 +326,8 @@ create_a_stream_on_index(Index) ->
 		List :: [{Type :: string(), Id :: string()}],
 		Func :: string()) -> Pid :: pid().
 create_virtual_stream(VStreamId, List, Func) ->
-	spawn(virtual_stream_process, create, [VStreamId, List, Func]).
+	{ok, Pid} = gen_virtual_stream_process:start_link(VStreamId, List, Func),
+	Pid.
 
 
 


### PR DESCRIPTION
This branch updates that a virtual stream can use the pub/sub system and that all virtual streams are initialized at start up and put under supervision... there is functionality to add more process under supervision dynamically
